### PR TITLE
Wrong extension name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "mschwemer/rte-ckeditor-wordcount",
+  "name": "mschwemer/rte_ckeditor_wordcount",
   "type": "typo3-cms-extension",
   "description": "Adds the word-count add-on to the CKEditor in TYPO3.",
   "homepage": "https://www.typo3worx.eu",


### PR DESCRIPTION
*-* leads to typo3conf/ext/rte-ckeditor-wordcount what's wrong and not allowed