### PR TITLE
[TASK] Reference the resource of the plugin only by folder name

### DIFF
--- a/Configuration/RTE/Plugin.yaml
+++ b/Configuration/RTE/Plugin.yaml
@@ -2,7 +2,7 @@
 editor:
   externalPlugins:
     notification:
-      resource: "EXT:rte_ckeditor_wordcount/Resources/Public/JavaScript/Plugins/notification/plugin.js"
+      resource: "EXT:rte_ckeditor_wordcount/Resources/Public/JavaScript/Plugins/notification/"
     wordcount:
-      resource: "EXT:rte_ckeditor_wordcount/Resources/Public/JavaScript/Plugins/wordcount/plugin.js"
+      resource: "EXT:rte_ckeditor_wordcount/Resources/Public/JavaScript/Plugins/wordcount/"
       showCharCount: true


### PR DESCRIPTION
It's common to only add the folder to a CKEditor plugin resource.